### PR TITLE
chore: rollup config alias add ext.

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -36,7 +36,7 @@ export default {
     }),
     alias({
       // avoid this plugin adding .js ext. to our path.
-      resolve: [''],
+      resolve: ['.js', '.jsx', '.sass', '.scss'],
       '@style': path.resolve(__dirname, 'src/style'),
       '@shared': path.resolve(__dirname, 'src/components/shared'),
     }),


### PR DESCRIPTION
rollup config alias add '.js', '.jsx', '.sass', '.scss' extensions