### PR TITLE
chore: add 'export' as well as 'export default' to enable tree-shaking

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,3 +6,7 @@ export default {
   version,
   Spinner,
 }
+export {
+  version,
+  Spinner,
+}

--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
     "classnames": "^2.2.5",
     "prop-types": "^15.6.0",
     "react": "^16.2.0",
-    "react-dom": "^16.2.0",
-    "react-transition-group": "^1.2.1"
+    "react-dom": "^16.2.0"
   },
   "devDependencies": {
     "@storybook/addon-actions": "^3.2.14",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -57,6 +57,7 @@ const entryCode =
 import { version } from './package.json'
 ${components.map(comp => `import ${comp} from './src/components/react/${comp}'`).join('\n')}
 
+export { version, ${components.join(', ')} }
 export default { version, ${components.join(', ')} }
 `
 

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -43,6 +43,7 @@ delete packageJson.scripts
 delete packageJson.betterScripts
 delete packageJson.devDependencies
 delete packageJson['pre-commit']
+packageJson.name = packageJson.name.toLowerCase()
 packageJson.main = './dest/ugli-ui.js'
 packageJson.files = ['./dest/ugli-ui.js', './dest/ugli-ui.css']
 fs.writeFileSync(`${buildDirectory}/package.json`, JSON.stringify(packageJson))


### PR DESCRIPTION
Tree shaking with only `export default` seem won't work, fixed.